### PR TITLE
Integrate Observability Practices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - '3000:3000'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: 'nextjs'
+    static_configs:
+      - targets: ['host.docker.internal:3000']

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,15 @@
+import { createLogger, format, transports } from 'winston';
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.json()
+  ),
+  transports: [
+    new transports.Console(),
+    new transports.File({ filename: 'combined.log' })
+  ]
+});
+
+export default logger;

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -1,0 +1,10 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import client from 'prom-client';
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+collectDefaultMetrics();
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Content-Type', client.register.contentType);
+  res.end(client.register.metrics());
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,8 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+const sdk = new NodeSDK({
+  instrumentations: [getNodeAutoInstrumentations()]
+});
+
+sdk.start();


### PR DESCRIPTION
To introduce observability practices into your Next.js application, we will integrate structured logging, metrics collection, distributed tracing, and real-time monitoring using tools like Prometheus, Grafana, and OpenTelemetry. Below are the detailed configurations and code snippets to achieve this.

### Analysis

1. **Structured Logging**: We will use a logging library like `winston` to implement structured logging. This will allow us to capture logs in a structured format, making it easier to analyze and search through logs.

2. **Metrics Collection**: Prometheus will be used to collect metrics from the application. We will expose a `/metrics` endpoint that Prometheus can scrape to gather metrics data.

3. **Distributed Tracing**: OpenTelemetry will be integrated to provide distributed tracing capabilities. This will help in tracking requests as they flow through different services.

4. **Real-Time Monitoring**: Grafana will be used to visualize the metrics collected by Prometheus, providing real-time monitoring dashboards.

### Suggestions

#### 1. Structured Logging with Winston

First, install the `winston` package:

```bash
npm install winston
```

Create a logger configuration file:

```ts
// src/logger.ts
import { createLogger, format, transports } from 'winston';

const logger = createLogger({
  level: 'info',
  format: format.combine(
    format.timestamp(),
    format.json()
  ),
  transports: [
    new transports.Console(),
    new transports.File({ filename: 'combined.log' })
  ]
});

export default logger;
```

#### 2. Metrics Collection with Prometheus

Install the `prom-client` package:

```bash
npm install prom-client
```

Set up a metrics endpoint:

```ts
// src/pages/api/metrics.ts
import { NextApiRequest, NextApiResponse } from 'next';
import client from 'prom-client';

const collectDefaultMetrics = client.collectDefaultMetrics;
collectDefaultMetrics();

export default function handler(req: NextApiRequest, res: NextApiResponse) {
  res.setHeader('Content-Type', client.register.contentType);
  res.end(client.register.metrics());
}
```

#### 3. Distributed Tracing with OpenTelemetry

Install OpenTelemetry packages:

```bash
npm install @opentelemetry/api @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node
```

Set up OpenTelemetry:

```ts
// src/telemetry.ts
import { NodeSDK } from '@opentelemetry/sdk-node';
import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';

const sdk = new NodeSDK({
  instrumentations: [getNodeAutoInstrumentations()]
});

sdk.start();
```

#### 4. Real-Time Monitoring with Grafana

Create a `docker-compose.yml` file to set up Prometheus and Grafana:

```yaml
version: '3.7'
services:
  prometheus:
    image: prom/prometheus
    volumes:
      - ./prometheus.yml:/etc/prometheus/prometheus.yml
    ports:
      - '9090:9090'

  grafana:
    image: grafana/grafana
    ports:
      - '3000:3000'
```

Create a `prometheus.yml` configuration file:

```yaml
scrape_configs:
  - job_name: 'nextjs'
    static_configs:
      - targets: ['host.docker.internal:3000']
```

### README Update

Update the `README.md` to include instructions for setting up observability:

```markdown
## Observability Setup

### Structured Logging
- Install dependencies: `npm install winston`
- Configure logger in `src/logger.ts`

### Metrics Collection
- Install dependencies: `npm install prom-client`
- Expose metrics endpoint in `src/pages/api/metrics.ts`

### Distributed Tracing
- Install dependencies: `npm install @opentelemetry/api @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node`
- Set up OpenTelemetry in `src/telemetry.ts`

### Real-Time Monitoring
- Use `docker-compose` to start Prometheus and Grafana
- Configure Prometheus with `prometheus.yml`
```

These configurations and code snippets will integrate observability practices into your application, providing structured logging, metrics collection, distributed tracing, and real-time monitoring capabilities.